### PR TITLE
ensure pip is installed, also added make clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ VENV_PATH := $(CURDIR)/$(VENV_NAME)
 # Check if the virtual environment already exists
 VENV_EXISTS := $(wildcard $(VENV_PATH))
 
+clean:
+	rm -rf $(VENV_PATH)
+
 setup_venv:
 ifndef VENV_EXISTS
 		python3 -m venv $(VENV_PATH)
@@ -16,6 +19,7 @@ else
 endif
 
 install_requirements: setup_venv
+	$(VENV_PATH)/bin/python -m ensurepip --upgrade
 	$(VENV_PATH)/bin/pip install -r $(CURDIR)/requirements.txt
 
 


### PR DESCRIPTION
Depending on system configuration / packages it is possible for the virtual env not to contain pip in the bin folder.

Pythons ensurepip module can be used to check for, and remedy this situation

Also added clean target for the Makefile